### PR TITLE
[#12, #55] 회원가입 프로필 사진 등록 + 회원가입 성공 시 팝업 노출 후 이전 페이지 라우팅

### DIFF
--- a/potato-market/src/App.jsx
+++ b/potato-market/src/App.jsx
@@ -13,11 +13,13 @@ function App() {
   useEffect(() => {
     firebase.auth().onAuthStateChanged((user) => {
       if (user) {
-        const db = firebase.firestore();
-        const userInfoRef = db.collection("users").doc(user.uid);
-        userInfoRef.get().then((doc) => {
-          console.log(`로그인상태 \nUID : ${user.uid} \n닉네임 : ${doc.data().nickname}`);
-        })
+        // const db = firebase.firestore();
+        // const userInfoRef = db.collection("users").doc(user.uid);
+        // userInfoRef.get().then((doc) => {
+        //   console.log(`로그인상태\nUID : ${user.uid} \n닉네임 : ${doc.data().nickname}`);
+        // })
+        let uid = user.uid;
+        console.log(`로그인상태\nUID : ${uid}`);
       } else {
         console.log('로그아웃상태');
       }

--- a/potato-market/src/App.jsx
+++ b/potato-market/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import Footer from './components/Footer';
@@ -9,13 +9,15 @@ import GlobalStyle from './styles/Global';
 
 function App() {
 
-  const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인상태 저장 예정
-
+  // 로그인 상태 체크 (로그인/로그아웃/새로고침 시 실행)
   useEffect(() => {
     firebase.auth().onAuthStateChanged((user) => {
       if (user) {
-        let uid = user.uid;
-        console.log('로그인상태', uid);
+        const db = firebase.firestore();
+        const userInfoRef = db.collection("users").doc(user.uid);
+        userInfoRef.get().then((doc) => {
+          console.log(`로그인상태 \nUID : ${user.uid} \n닉네임 : ${doc.data().nickname}`);
+        })
       } else {
         console.log('로그아웃상태');
       }

--- a/potato-market/src/components/FormInput.jsx
+++ b/potato-market/src/components/FormInput.jsx
@@ -2,6 +2,64 @@ import styled from 'styled-components';
 
 import { gray5, primaryColor } from '../styles/Global';
 
+export const FormInputImage = () => {
+  return (
+    <>
+      <LabelText htmlFor="profileImage">프로필 사진</LabelText>
+      <InputBox>
+        <input accept=".png, .jpg, .jpeg, .svg" id="profileImage" type="file" />
+      </InputBox>
+    </>
+  )
+};
+
+export const FormInputLocation = ({ process }) => {
+  return (
+    <>
+      <LabelText htmlFor="userLocation">주소</LabelText>
+      {process === "search" &&
+        <InputBox>
+          <Button type="button">주소 검색</Button>
+          <DescText>주소에 따라서 내 동네가 설정됩니다</DescText>
+        </InputBox>
+      }
+      {process === "detail" &&
+        <InputBox>
+          <div className="loca">
+            <input readOnly id="userLocation" name="userLocation" type="text" value="경기도 용인시 기흥구 기흥1로" />
+            <Button type="button">재검색</Button>
+          </div>
+          <input id="userLocationDetail" name="userLocationDetail" placeholder="상세주소를 입력해주세요" type="text" />
+          <DescText>주소에 따라서 내 동네가 설정됩니다</DescText>
+        </InputBox>
+      }
+    </>
+  )
+};
+
+const FormInput = ({ id, type, onChange, value, placeholder, text, desc, valid, label, button }) => {
+  return (
+    <>
+      {label
+        ? <LabelText htmlFor={id}>{text}</LabelText>
+        : <label className="a11yHidden" htmlFor={id}>{text}</label>
+      }
+      <InputBox>
+        <input id={id} name={id} placeholder={placeholder} type={type} value={value} onChange={onChange} />
+        {desc &&
+          <DescText>{desc}</DescText>
+        }
+        {valid &&
+          <VaildNotice>{valid}</VaildNotice>
+        }
+      </InputBox>
+      {button &&
+        <Button type="button">{button}</Button>
+      }
+    </>
+  )
+};
+
 const LabelText = styled.label`
   display: inline-block;
   flex-shrink: 0;
@@ -87,63 +145,5 @@ const Button = styled.button`
     max-width: none;
   }
 `;
-
-export const FormInputImage = () => {
-  return (
-    <>
-      <LabelText htmlFor="userProfileImage">프로필 사진</LabelText>
-      <InputBox>
-        <input accept=".png, .jpg, .jpeg, .svg" id="userProfileImage" type="file" />
-      </InputBox>
-    </>
-  )
-};
-
-export const FormInputLocation = ({ process }) => {
-  return (
-    <>
-      <LabelText htmlFor="userLocation">주소</LabelText>
-      {process === "search" &&
-        <InputBox>
-          <Button type="button">주소 검색</Button>
-          <DescText>주소에 따라서 내 동네가 설정됩니다</DescText>
-        </InputBox>
-      }
-      {process === "detail" &&
-        <InputBox>
-          <div className="loca">
-            <input readOnly id="userLocation" name="userLocation" type="text" value="경기도 용인시 기흥구 기흥1로" />
-            <Button type="button">재검색</Button>
-          </div>
-          <input id="userLocationDetail" name="userLocationDetail" placeholder="상세주소를 입력해주세요" type="text" />
-          <DescText>주소에 따라서 내 동네가 설정됩니다</DescText>
-        </InputBox>
-      }
-    </>
-  )
-};
-
-const FormInput = ({ id, type, onChange, value, placeholder, text, desc, valid, label, button }) => {
-  return (
-    <>
-      {label
-        ? <LabelText htmlFor={id}>{text}</LabelText>
-        : <label className="a11yHidden" htmlFor={id}>{text}</label>
-      }
-      <InputBox>
-        <input id={id} name={id} placeholder={placeholder} type={type} value={value} onChange={onChange} />
-        {desc &&
-          <DescText>{desc}</DescText>
-        }
-        {valid &&
-          <VaildNotice>{valid}</VaildNotice>
-        }
-      </InputBox>
-      {button &&
-        <Button type="button">{button}</Button>
-      }
-    </>
-  )
-};
 
 export default FormInput;

--- a/potato-market/src/components/Popup.jsx
+++ b/potato-market/src/components/Popup.jsx
@@ -4,10 +4,7 @@ import { gray2 } from '../styles/Global';
 
 import { primaryColor } from '@/styles/global';
 
-function Popup({ text, showPopup, setShowPopup }) {
-  const onClose = () => {
-    setShowPopup(!showPopup);
-  }
+function Popup({ text, onClose }) {
   return (
     <PopWrapper>
       <div className="pop">

--- a/potato-market/src/firebase.js
+++ b/potato-market/src/firebase.js
@@ -1,6 +1,7 @@
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
 import 'firebase/compat/firestore';
+import "firebase/compat/storage";
 
 // const {
 //   VITE_API_KEY,

--- a/potato-market/src/pages/SignIn.jsx
+++ b/potato-market/src/pages/SignIn.jsx
@@ -121,9 +121,10 @@ const SignIn = () => {
       </LoginForm>
       {showPopup &&
         <Popup
-          setShowPopup={setShowPopup}
-          showPopup={showPopup}
           text={"아이디, 비밀번호를 확인해주세요."}
+          onClose={() => {
+            setShowPopup(false);
+          }}
         />
       }
     </Section >

--- a/potato-market/src/pages/SignUp.jsx
+++ b/potato-market/src/pages/SignUp.jsx
@@ -28,7 +28,6 @@ function SignUp() {
     password: "",
     confirmPassword: "",
     nickname: "",
-    // profileImage: '',
     // location: "",
   });
 
@@ -45,11 +44,19 @@ function SignUp() {
       const userCredential = await firebase
         .auth()
         .createUserWithEmailAndPassword(formState.email, formState.password);
+
       const db = firebase.firestore();
+      const storage = firebase.storage();
+      const file = document.querySelector('#profileImage').files[0];
+      const uploadRef = storage.ref().child('profileImages/' + file.name);
+      await uploadRef.put(file);
+      const profileImageUrl = await uploadRef.getDownloadURL();
+
       await db.collection("users").doc(userCredential.user.uid).set({
         email: formState.email,
         phoneNumber: formState.phoneNumber,
         nickname: formState.nickname,
+        profileImage: profileImageUrl,
       });
       setShowPopup(true);
     } catch (error) {

--- a/potato-market/src/pages/SignUp.jsx
+++ b/potato-market/src/pages/SignUp.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import FormInput, { FormInputLocation, FormInputImage } from '../components/FormInput';
 import FormTerms from '../components/FormTerms';
+import Popup from '../components/Popup';
 import Postcode from '../components/Postcode';
 import FormButton from '../styles/FormButton';
 
@@ -18,6 +19,8 @@ function SignUp() {
 
   // 회원가입 가능 상태 조절 예정
   const [confirmState, setConfirmState] = useState(false);
+
+  const [showPopup, setShowPopup] = useState(false);
 
   const [formState, setFormState] = useState({
     phoneNumber: "",
@@ -48,7 +51,7 @@ function SignUp() {
         phoneNumber: formState.phoneNumber,
         nickname: formState.nickname,
       });
-      navigate(-1);
+      setShowPopup(true);
     } catch (error) {
       setError(error.message);
     }
@@ -203,6 +206,15 @@ function SignUp() {
           >가입하기</FormButton>
         </fieldset>
       </SignUpForm>
+      {showPopup &&
+        <Popup
+          text={"회원가입에 성공했습니다! 어서오세요!"}
+          onClose={() => {
+            setShowPopup(false);
+            navigate(-1);
+          }}
+        />
+      }
     </Section >
   )
 };


### PR DESCRIPTION
<!-- PR의 제목을 "[#이슈 번호] 이슈 명" 으로 작성해주세요. -->

## ✨ 구현 기능
<!-- 한 줄로 간결히 설명해주세요 -->
회원가입 기능 추가 및 고도화

## ✅ 작업 내용 상세
- 회원가입 중 프로필 사진 업로드
  - [x] 프로필 사진 storage에 업로드
  - [x] 프로필 사진 url을 해당 회원정보 firestore database에 저장
  - [ ] 프로필 사진 미리보기 마크업&스타일링
- [x] 회원가입 완료 시, 성공 팝업 노출
  - 팝업의 확인 버튼을 눌러야만 다음 동작 진행
  - ![image](https://user-images.githubusercontent.com/26590099/226197764-b852c48d-176e-49ee-b14c-af58410b396b.png)


## 🙏 비고
<!-- 공유사항, 특이사항 또는 작업 회고 등 편안하게 작성해주세요 -->
1) 회원가입 성공 팝업이 뜨기 전까지의 시간이 오래걸려 로딩 스피너 추가 또는 코드 개선 진행 예정입니다
2) 프로필 사진을 유저가 미리보기 할 수 있도록 마크업/스타일링 추가 작업 진행 예정입니다