### PR TITLE
[#55] 회원가입 폼 프로필 사진 등록 기능 구현 (2차)

### DIFF
--- a/potato-market/src/components/FormInput.jsx
+++ b/potato-market/src/components/FormInput.jsx
@@ -1,13 +1,36 @@
+import { useState } from 'react';
+
 import styled from 'styled-components';
 
 import { gray5, primaryColor } from '../styles/Global';
 
 export const FormInputImage = () => {
+
+  const [previewImage, setPreviewImage] = useState("../src/assets/default_profile.png");
+
+  const handleFileInputChange = (e) => {
+    const uploadedImage = e.target.files[0];
+    if (uploadedImage) {
+      const imageUrl = URL.createObjectURL(uploadedImage);
+      setPreviewImage(imageUrl);
+    }
+  };
+
   return (
     <>
       <LabelText htmlFor="profileImage">프로필 사진</LabelText>
       <InputBox>
-        <input accept=".png, .jpg, .jpeg, .svg" id="profileImage" type="file" />
+        <img
+          alt="프로필 이미지사진 미리보기"
+          className="profile-image-preview"
+          src={previewImage}
+        />
+        <input
+          accept=".png, .jpg, .jpeg, .svg"
+          id="profileImage"
+          type="file"
+          onChange={handleFileInputChange}
+        />
       </InputBox>
     </>
   )
@@ -91,13 +114,25 @@ const InputBox = styled.div`
     border-radius: 4px;
     box-sizing: border-box;
   }
-  input[type="file"]::file-selector-button {
-    border: 1px solid ${primaryColor};
-    color: ${primaryColor};
-    font-weight: 600;
+  input[type="file"] {
+    width: 340px;
+    &::file-selector-button {
+      border: 1px solid ${primaryColor};
+      color: ${primaryColor};
+      font-weight: 600;
+      cursor: pointer;
+    }
   }
   button {
     width: 340px;
+  }
+  .profile-image-preview {
+    width: 100px;
+    height: 100px;
+    margin: 0 auto;
+    object-fit: cover;
+    border-radius: 50%;
+    border: 1px solid ${gray5};
   }
   .loca {
     display: flex;
@@ -113,6 +148,7 @@ const InputBox = styled.div`
     input[type="password"],
     input[type="tel"],
     input[type="email"],
+    input[type="file"],
     input[type="file"]::file-selector-button,
     button {
       width: 100%;

--- a/potato-market/src/pages/SignUp.jsx
+++ b/potato-market/src/pages/SignUp.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
-import { usersRef } from '../firebase';
 
 import styled from 'styled-components';
 
@@ -9,18 +8,19 @@ import FormInput, { FormInputLocation, FormInputImage } from '../components/Form
 import FormTerms from '../components/FormTerms';
 import Popup from '../components/Popup';
 import Postcode from '../components/Postcode';
+import { usersRef } from '../firebase';
 import FormButton from '../styles/FormButton';
 
-import { gray3, gray8 ,primaryColor} from '../styles/Global';
+import { gray3, gray8, primaryColor } from '../styles/Global';
 
 import firebase from '@/firebase';
 
 function SignUp() {
-  
+
   const navigate = useNavigate();
   // 전체 선택 상태  
   const [isCheckedAll, setIsCheckedAll] = useState(false);
-  
+
   // 약관 보기 개별 선택 상태
   const [isCheckedOne, setIsCheckedOne] = useState(false);
   const [isCheckedTwo, setIsCheckedTwo] = useState(false);
@@ -35,7 +35,7 @@ function SignUp() {
     password: "",
     confirmPassword: "",
     nickname: "",
-    Agree: isCheckedThree ? "무료배송, 할인쿠폰 등 혜택/정보 수신 동의함":"",
+    Agree: isCheckedThree ? "무료배송, 할인쿠폰 등 혜택/정보 수신 동의함" : "",
     // location: "",
   });
 
@@ -48,12 +48,12 @@ function SignUp() {
     e.preventDefault();
     // const currentUserUid = firebase.auth().currentUser.uid;
     // const usersRef = firebase.db().collection("users");
-    
+
     if (formState.password !== formState.confirmPassword) {
       setError("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
       return;
     }
-    if( !isCheckedOne || !isCheckedTwo || !isCheckedFour){
+    if (!isCheckedOne || !isCheckedTwo || !isCheckedFour) {
       alert("필수 이용 약관에 동의하셔야합니다.")
       return
     }
@@ -71,7 +71,7 @@ function SignUp() {
       const db = firebase.firestore();
       const storage = firebase.storage();
       const file = document.querySelector('#profileImage').files[0];
-      const uploadRef = storage.ref().child('profileImages/' + file.name);
+      const uploadRef = storage.ref().child('profileImages/' + (new Date().getTime() + Math.random().toString(36).substr(2, 5)));
       await uploadRef.put(file);
       const profileImageUrl = await uploadRef.getDownloadURL();
 
@@ -140,14 +140,14 @@ function SignUp() {
         });
     }
   };
-  
+
   const handleCheckboxChangeFour = (event) => {
     setIsCheckedFour(event.target.checked);
     if (!event.target.checked) {
       setIsCheckedAll(false);
     }
   };
-  
+
   return (
     <Section>
       <h2>회원가입</h2>
@@ -232,11 +232,11 @@ function SignUp() {
           <div className="term-list">
             <span className="term-title">이용약관동의</span>
             <div className="term-check">
-              <FormTerms all checked={isCheckedAll} onChange={handleCheckboxChangeAll}/>            
-              <FormTerms id={"term1"} text={"이용약관 동의 (필수)"}   checked={isCheckedOne} onChange={handleCheckboxChangeOne}/>
-              <FormTerms id={"term2"} text={"개인정보 수집 · 이용 동의 (필수)"}   checked={isCheckedTwo} onChange={handleCheckboxChangeTwo}/>
-              <FormTerms id={"term3"} text={"무료배송, 할인쿠폰 등 혜택/정보 수신 동의 (선택)"}  value={formState.agree} checked={isCheckedThree} onChange={handleCheckboxChangeThree}/>
-              <FormTerms id={"term4"} text={"본인은 만 14세 이상입니다. (필수)"}  checked={isCheckedFour} onChange={handleCheckboxChangeFour}/>
+              <FormTerms all checked={isCheckedAll} onChange={handleCheckboxChangeAll} />
+              <FormTerms checked={isCheckedOne} id={"term1"} text={"이용약관 동의 (필수)"} onChange={handleCheckboxChangeOne} />
+              <FormTerms checked={isCheckedTwo} id={"term2"} text={"개인정보 수집 · 이용 동의 (필수)"} onChange={handleCheckboxChangeTwo} />
+              <FormTerms checked={isCheckedThree} id={"term3"} text={"무료배송, 할인쿠폰 등 혜택/정보 수신 동의 (선택)"} value={formState.agree} onChange={handleCheckboxChangeThree} />
+              <FormTerms checked={isCheckedFour} id={"term4"} text={"본인은 만 14세 이상입니다. (필수)"} onChange={handleCheckboxChangeFour} />
             </div>
           </div>
           <FormButton
@@ -248,7 +248,7 @@ function SignUp() {
               pointerEvents: disabled ? "none" : "auto",
             }}
             onClick={handleSignUp}
-            >가입하기</FormButton>
+          >가입하기</FormButton>
         </fieldset>
       </SignUpForm>
       {showPopup &&


### PR DESCRIPTION
<!-- PR의 제목을 "[#이슈 번호] 이슈 명" 으로 작성해주세요. -->

## ✨ 구현 기능
<!-- 한 줄로 간결히 설명해주세요 -->
회원가입 폼 > 프로필 이미지 등록 기능 구현

## ✅ 작업 내용 상세
- stroge와 firestore 연동은 지난 작업에서 완료했습니다 
- [x] 프로필 이미지 미리보기 마크업&스타일링
- [x] 프로필 이미지 storage에 올라가는 파일명 난수화
![image](https://user-images.githubusercontent.com/26590099/226491983-6ab28d3d-5f4d-4026-b85c-5ccd559c41ad.png)
![image](https://user-images.githubusercontent.com/26590099/226492018-d25d36f1-d210-46c7-8ae7-05691b10a358.png)
![image](https://user-images.githubusercontent.com/26590099/226492152-8c65c3ae-3f84-47cd-b7fe-29d844b5fa69.png)


## 🙏 비고
<!-- 공유사항, 특이사항 또는 작업 회고 등 편안하게 작성해주세요 -->