### PR TITLE
[#55] 프로필 사진 미업로드 시, 기본 이미지가 적용되도록 처리

### DIFF
--- a/potato-market/src/pages/SignUp.jsx
+++ b/potato-market/src/pages/SignUp.jsx
@@ -37,8 +37,7 @@ function SignUp() {
     confirmPassword: "",
     nickname: "",
     Agree: isCheckedThree ? "무료배송, 할인쿠폰 등 혜택/정보 수신 동의함" : "",
-  },
-  );
+  });
 
   // 회원가입 폼 disabled 조건
   const disabled = !formState.phoneNumber || !formState.email || !formState.password || !formState.confirmPassword || !formState.nickname
@@ -63,13 +62,21 @@ function SignUp() {
     }
 
     try {
+      // Firebase Authentication : 신규 계정 생성
       const userCredential = await auth.createUserWithEmailAndPassword(formState.email, formState.password);
+
+      // Firebase Storage : 프로필 사진 storage로 전송 후 업로드 된 url 받아오기
+      let profileImageUrl = "https://firebasestorage.googleapis.com/v0/b/patato-market.appspot.com/o/default_profile.png?alt=media&token=1c915d92-e3d7-4b06-9d99-03340d7bd805"; // 기본 이미지
       const file = document.querySelector('#profileImage').files[0];
-      const uploadRef = storage.ref().child('profileImages/' + (new Date().getTime() + Math.random().toString(36).substr(2, 5)));
-      const uploadTask = uploadRef.put(file);
-      const profileImageUrl = await uploadTask.then(
-        (snapshot) => snapshot.ref.getDownloadURL()
-      );
+      if (file) {
+        const uploadRef = storage.ref().child('profileImages/' + (new Date().getTime() + Math.random().toString(36).substr(2, 5)));
+        const uploadTask = uploadRef.put(file);
+        profileImageUrl = await uploadTask.then(
+          (snapshot) => snapshot.ref.getDownloadURL()
+        );
+      }
+
+      // Firebase FireStore : 회원정보 신규 저장
       const userDoc = usersRef.doc(userCredential.user.uid);
       const userBatch = db.batch();
       userBatch.set(userDoc, {

--- a/potato-market/src/pages/SignUp.jsx
+++ b/potato-market/src/pages/SignUp.jsx
@@ -264,7 +264,7 @@ function SignUp() {
           text={"회원가입에 성공했습니다! 어서오세요!"}
           onClose={() => {
             setShowPopup(false);
-            navigate(-1);
+            navigate("/");
           }}
         />
       }


### PR DESCRIPTION
<!-- PR의 제목을 "[#이슈 번호] 이슈 명" 으로 작성해주세요. -->

## ✨ 구현 기능
<!-- 한 줄로 간결히 설명해주세요 -->
프로필사진 관련 에러 해결 겸 회원가입 코드 3글자정도 수정

## ✅ 작업 내용 상세
- [x] 회원가입 중 프로필 사진 미 등록 시 기본 이미지가 적용되도록 제어
  - 기존 : 미 등록 시 회원가입 에러 발생
  - storage에 기본 프로필 사진 default_profile.png 등록 후, 빈 값일 때 가져오도록 적용
- [x] 회원가입 완료 팝업 "확인" 버튼 클릭 시 navigate(-1)(뒤로가기) 기능이 동작하지 않아 홈으로 이동하게 임시 해결

## 🙏 비고
<!-- 공유사항, 특이사항 또는 작업 회고 등 편안하게 작성해주세요 -->