### PR TITLE
[#66 #68] 나의 매물 조회 페이지 생성

### DIFF
--- a/potato-market/src/firebase.js
+++ b/potato-market/src/firebase.js
@@ -37,5 +37,6 @@ export const db = firebase.firestore();
 export const storage = firebase.storage();
 
 export const usersRef = db.collection('users'); // 유저 정보 컬렉션
+export const userWriteRef = db.collection('UserWrite'); // 게시글 정보 컬렉션
 
 export default firebase;

--- a/potato-market/src/pages/Home.jsx
+++ b/potato-market/src/pages/Home.jsx
@@ -1,58 +1,57 @@
 import { useEffect, useState } from "react";
 
-import {onSnapshot} from "firebase/firestore"
+import { onSnapshot } from "firebase/firestore"
 import styled, { createGlobalStyle } from "styled-components";
 
-import { ProductList } from "./HotArticles/HotArticles";
-import Product from "../components/product";
 import { gray1, gray2 } from "../styles/Global";
 
+import Product from "@/components/product";
+
 import firebase from '@/firebase';
+import ProductList from '@/styles/ProductList';
 
 const db = firebase.firestore();
 const q = db.collection("UserWrite");
 
-export default function Home(){
-  
-  const [ readyToRender, setReadyToRender] = useState(0);
+export default function Home() {
+
+  const [readyToRender, setReadyToRender] = useState(0);
   const [checkArr, setCheckArr] = useState([]);
-  
-  useEffect(()=>{
-    onSnapshot(q, (snapshot)=>{
+
+  useEffect(() => {
+    onSnapshot(q, (snapshot) => {
       const newArr = snapshot.docs.map(doc => {
         return {
-          id : doc.id,
+          id: doc.id,
           ...doc.data()
         }
       })
-
       newArr.sort((b, a) => a.check - b.check);
       setCheckArr(newArr.slice(0, 8));
       setReadyToRender(1);
-
     })
   }, [checkArr])
 
   return (
     <>
-      <HomeGlobal/>
+      <HomeGlobal />
       <MainTop imgheight="50.25rem" imgwidth="42.813rem">
         <div className="home-main-description">
-          <h2>당신 근처의<br/>감자마켓</h2>
-          <p>중고 거래부터 동네 정보까지, 이웃과 함께해요. <br/>
-          가깝고 따뜻한 당신의 근처를 만들어요.</p>
+          <h2>당신 근처의<br />감자마켓</h2>
+          <p>중고 거래부터 동네 정보까지, 이웃과 함께해요. <br />
+            가깝고 따뜻한 당신의 근처를 만들어요.</p>
         </div>
         <div className="home-main-image">
-          <img alt="" src="https://d1unjqcospf8gs.cloudfront.net/assets/home/main/3x/image-top-68ba12f0da7b5af9a574ed92ca8b3a9c0068db176b566dd374ee50359693358b.png"/>
+          <img alt="" src="https://d1unjqcospf8gs.cloudfront.net/assets/home/main/3x/image-top-68ba12f0da7b5af9a574ed92ca8b3a9c0068db176b566dd374ee50359693358b.png" />
         </div>
       </MainTop>
 
       <MainReversed imgheight="" imgwidth="">
         <div className="home-main-image">
-          <img alt="" src="https://d1unjqcospf8gs.cloudfront.net/assets/home/main/3x/image-1-39ac203e8922f615aa3843337871cb654b81269e872494128bf08236157c5f6a.png"/>
+          <img alt="" src="https://d1unjqcospf8gs.cloudfront.net/assets/home/main/3x/image-1-39ac203e8922f615aa3843337871cb654b81269e872494128bf08236157c5f6a.png" />
         </div>
         <div className="home-main-description">
-          <h2>우리 동네<br/> 중고 직거래 마켓</h2>
+          <h2>우리 동네<br /> 중고 직거래 마켓</h2>
           <p>동네 주민들과 가깝고 따뜻한 거래를 지금 경험해보세요.</p>
           <div className="button-wrap">
             <button type="button">인기매물 보기</button>
@@ -64,10 +63,10 @@ export default function Home(){
       <HotArticles8>
         <h2>중고거래 인기매물</h2>
         <ProductList className="Hot8">
-          { readyToRender ? checkArr.map(
-              ({ content, title, price, side, imgsrc, id, check, heart }, index) =>
-              (<Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />)) 
-            : <p>Render Failed</p> 
+          {readyToRender ? checkArr.map(
+            ({ content, title, price, side, imgsrc, id, check, heart }, index) =>
+              (<Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />))
+            : <p>Render Failed</p>
           }
         </ProductList>
         <UnderlineButton>
@@ -91,7 +90,7 @@ export default function Home(){
         </ul>
       </HomeKeywords>
     </>
-  ) 
+  )
 }
 
 // Styled Components

--- a/potato-market/src/pages/HotArticles.jsx
+++ b/potato-market/src/pages/HotArticles.jsx
@@ -1,7 +1,0 @@
-const HotArticles = () => {
-  return (
-    <h2>HotArticles</h2>
-  )
-};
-
-export default HotArticles;

--- a/potato-market/src/pages/HotArticles/HotArticles.jsx
+++ b/potato-market/src/pages/HotArticles/HotArticles.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import {onSnapshot} from "firebase/firestore"
-import styled from 'styled-components';
+import { onSnapshot } from "firebase/firestore"
 
 import Filter from "./Filter";
 
@@ -9,8 +8,9 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 
 import Product from "@/components/product";
 
-import firebase  from '@/firebase';
-import {ContainerGlobalStyle} from '@/styles/ContainerGlobalStyle';
+import firebase from '@/firebase';
+import { ContainerGlobalStyle } from '@/styles/ContainerGlobalStyle';
+import ProductList from '@/styles/ProductList';
 
 const db = firebase.firestore();
 const q = db.collection("UserWrite");
@@ -18,65 +18,47 @@ const q = db.collection("UserWrite");
 let newArr = [];
 
 // console.log(serverdata)
-function HotArticles(){
-  const [render,Setrender] = useState(0);
-  useEffect(()=>{
+function HotArticles() {
+  const [render, Setrender] = useState(0);
+  useEffect(() => {
     newArr = [];
-  //   db.collection('UserWrite').get().then((item)=>{
-  //     item.forEach((item)=>{ 
-  //     serverdata[i] = item.data();
-  //     i++;
-  //     Setrender(1);      
-  //     serverdata.sort((b, a) => a.date - b.date)
-  //     // console.log(serverdata)
-  //     // console.log(orderedDate)
-  // }
-  // )})
-  onSnapshot(q,(snapshot)=>{
-    snapshot.docs.map((doc)=>{
-      const newObj = {
-        id : doc.id,
-        ...doc.data()
-      }
-      newArr.push(newObj);
-      newArr.sort((b, a) => a.date - b.date);
-      Setrender(1);
-      // console.log(newArr);
+    //   db.collection('UserWrite').get().then((item)=>{
+    //     item.forEach((item)=>{ 
+    //     serverdata[i] = item.data();
+    //     i++;
+    //     Setrender(1);      
+    //     serverdata.sort((b, a) => a.date - b.date)
+    //     // console.log(serverdata)
+    //     // console.log(orderedDate)
+    // }
+    // )})
+    onSnapshot(q, (snapshot) => {
+      snapshot.docs.map((doc) => {
+        const newObj = {
+          id: doc.id,
+          ...doc.data()
+        }
+        newArr.push(newObj);
+        newArr.sort((b, a) => a.date - b.date);
+        Setrender(1);
+        // console.log(newArr);
+      })
     })
-  })
-},[])
-  
-  return(
+  }, [])
+
+  return (
     <main className="wrapper">
       <ContainerGlobalStyle />
       <h2 className="articleTitle">중고거래 인기매물</h2>
       <Filter />
-      <ProductList >
+      <ProductList>
         <h3 className="a11yHidden">중고거래 매물리스트</h3>
-        {render?newArr.map(({content,title,price,side,imgsrc,id,check,heart},index)=>(
+        {render ? newArr.map(({ content, title, price, side, imgsrc, id, check, heart }, index) => (
           <Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />
-        )):<LoadingSpinner className="loading"/>}
+        )) : <LoadingSpinner className="loading" />}
       </ProductList>
     </main>
   )
 }
-
-const ProductList = styled.section`
-  margin: 35px auto;
-  display: grid;
-  gap: 55px;
-  grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: 309px;
-  & .loading{
-    left:43%;
-    position: absolute;
-  }
-  @media (max-width: 767px){
-    grid-template-columns: repeat(2, 1fr);
-  }
-  @media (min-width:768px) and (max-width: 1023px){
-    grid-template-columns: repeat(3, 1fr);
-  }
-`
 
 export default HotArticles;

--- a/potato-market/src/pages/MyArticle.jsx
+++ b/potato-market/src/pages/MyArticle.jsx
@@ -1,6 +1,42 @@
-const MyArticle = () => {
+import { useEffect, useState } from 'react';
+
+import LoadingSpinner from '@/components/LoadingSpinner';
+import Product from "@/components/product";
+
+import { userWriteRef } from '@/firebase';
+import { ContainerGlobalStyle } from '@/styles/ContainerGlobalStyle';
+import ProductList from '@/styles/ProductList';
+
+let newArr = [];
+
+function MyArticle() {
+  const [render, Setrender] = useState(0);
+  useEffect(() => {
+    newArr = [];
+    userWriteRef.onSnapshot((snapshot) => {
+      snapshot.docs.map((doc) => {
+        const newObj = {
+          id: doc.id,
+          ...doc.data()
+        }
+        newArr.push(newObj);
+        newArr.sort((b, a) => a.date - b.date);
+        Setrender(1);
+        // console.log(newArr);
+      })
+    })
+  }, [])
   return (
-    <h2>MyArticle</h2>
+    <main className="wrapper">
+      <ContainerGlobalStyle />
+      <h2 className="articleTitle">내가 등록한 매물</h2>
+      <ProductList >
+        <h3 className="a11yHidden">중고거래 매물리스트</h3>
+        {render ? newArr.map(({ content, title, price, side, imgsrc, id, check, heart }, index) => (
+          <Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />
+        )) : <LoadingSpinner className="loading" />}
+      </ProductList>
+    </main>
   )
 };
 

--- a/potato-market/src/pages/MyArticle.jsx
+++ b/potato-market/src/pages/MyArticle.jsx
@@ -1,40 +1,49 @@
 import { useEffect, useState } from 'react';
 
+import { useRecoilState } from "recoil";
+
 import LoadingSpinner from '@/components/LoadingSpinner';
 import Product from "@/components/product";
 
 import { userWriteRef } from '@/firebase';
+import { userId } from '@/stores/userAuth';
 import { ContainerGlobalStyle } from '@/styles/ContainerGlobalStyle';
 import ProductList from '@/styles/ProductList';
 
 let newArr = [];
 
 function MyArticle() {
-  const [render, Setrender] = useState(0);
+  const [render, setRender] = useState(0);
+  const [userUid] = useRecoilState(userId);
+
   useEffect(() => {
     newArr = [];
-    userWriteRef.onSnapshot((snapshot) => {
-      snapshot.docs.map((doc) => {
+    const query = userWriteRef.where('userId', '==', userUid); // 현재 사용자의 uid와 일치하는 문서 가져오기
+    query.onSnapshot((snapshot) => {
+      snapshot.docs.map((doc) => { // 각 문서 객체화
         const newObj = {
-          id: doc.id,
-          ...doc.data()
+          id: doc.id, // 객체의 아이디 값 지정
+          ...doc.data() // 기존 데이터들을 객체 형태로 받아옴
         }
         newArr.push(newObj);
         newArr.sort((b, a) => a.date - b.date);
-        Setrender(1);
-        // console.log(newArr);
-      })
-    })
-  }, [])
+        setRender(1);
+      });
+    });
+  }, [userUid])
+
   return (
     <main className="wrapper">
       <ContainerGlobalStyle />
       <h2 className="articleTitle">내가 등록한 매물</h2>
       <ProductList >
         <h3 className="a11yHidden">중고거래 매물리스트</h3>
-        {render ? newArr.map(({ content, title, price, side, imgsrc, id, check, heart }, index) => (
-          <Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />
-        )) : <LoadingSpinner className="loading" />}
+        {render
+          ? newArr.map(({ content, title, price, side, imgsrc, id, check, heart }, index) => (
+            <Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />
+          ))
+          : <LoadingSpinner className="loading" />
+        }
       </ProductList>
     </main>
   )

--- a/potato-market/src/pages/MyArticle.jsx
+++ b/potato-market/src/pages/MyArticle.jsx
@@ -10,27 +10,23 @@ import { userId } from '@/stores/userAuth';
 import { ContainerGlobalStyle } from '@/styles/ContainerGlobalStyle';
 import ProductList from '@/styles/ProductList';
 
-let newArr = [];
-
 function MyArticle() {
-  const [render, setRender] = useState(0);
+  const [render, setRender] = useState(false);
   const [userUid] = useRecoilState(userId);
+  const [newArr, setNewArr] = useState([]);
 
   useEffect(() => {
-    newArr = [];
     const query = userWriteRef.where('userId', '==', userUid); // 현재 사용자의 uid와 일치하는 문서 가져오기
     query.onSnapshot((snapshot) => {
-      snapshot.docs.map((doc) => { // 각 문서 객체화
-        const newObj = {
-          id: doc.id, // 객체의 아이디 값 지정
-          ...doc.data() // 기존 데이터들을 객체 형태로 받아옴
-        }
-        newArr.push(newObj);
-        newArr.sort((b, a) => a.date - b.date);
-        setRender(1);
-      });
+      const docs = snapshot.docs.map((doc) => ({ // 각 문서 객체화
+        id: doc.id, // 객체의 아이디 값 지정
+        ...doc.data() // 기존 데이터들을 객체 형태로 받아옴
+      }));
+      docs.sort((b, a) => a.date - b.date);
+      setNewArr(docs);
+      setRender(true);
     });
-  }, [userUid])
+  }, [userUid]);
 
   return (
     <main className="wrapper">

--- a/potato-market/src/pages/SignUp.jsx
+++ b/potato-market/src/pages/SignUp.jsx
@@ -36,8 +36,8 @@ function SignUp() {
     password: "",
     confirmPassword: "",
     nickname: "",
-    Agree: isCheckedThree ? "무료배송, 할인쿠폰 등 혜택/정보 수신 동의함":"",
-    },
+    Agree: isCheckedThree ? "무료배송, 할인쿠폰 등 혜택/정보 수신 동의함" : "",
+  },
   );
 
   // 회원가입 폼 disabled 조건
@@ -65,21 +65,23 @@ function SignUp() {
     try {
       const userCredential = await auth.createUserWithEmailAndPassword(formState.email, formState.password);
       const file = document.querySelector('#profileImage').files[0];
-
       const uploadRef = storage.ref().child('profileImages/' + (new Date().getTime() + Math.random().toString(36).substr(2, 5)));
-      await uploadRef.put(file);
-      const profileImageUrl = await uploadRef.getDownloadURL();
-
-      await db.collection("users").doc(userCredential.user.uid).set({
+      const uploadTask = uploadRef.put(file);
+      const profileImageUrl = await uploadTask.then(
+        (snapshot) => snapshot.ref.getDownloadURL()
+      );
+      const userDoc = usersRef.doc(userCredential.user.uid);
+      const userBatch = db.batch();
+      userBatch.set(userDoc, {
         email: formState.email,
         phoneNumber: formState.phoneNumber,
         nickname: formState.nickname,
         profileImage: profileImageUrl,
         agree: isCheckedThree,
-        location : {
-          sido : location.sido,
+        location: {
+          sido: location.sido,
           sigungu: location.sigungu,
-          bname : location.bname,
+          bname: location.bname,
         }
       });
       await userBatch.commit();
@@ -222,7 +224,7 @@ function SignUp() {
               <FormInputImage />
             </li>
             <li className="form-item">
-              <FormInputAddress 
+              <FormInputAddress
                 location={location}
                 setLocation={setLocation}
               />

--- a/potato-market/src/styles/ProductList.js
+++ b/potato-market/src/styles/ProductList.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+const ProductList = styled.section`
+  margin: 35px auto;
+  display: grid;
+  gap: 55px;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: 309px;
+  & .loading{
+    left:43%;
+    position: absolute;
+  }
+  @media (max-width: 767px){
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (min-width:768px) and (max-width: 1023px){
+    grid-template-columns: repeat(3, 1fr);
+  }
+`
+
+export default ProductList;


### PR DESCRIPTION
<!-- PR의 제목을 "[#이슈 번호] 이슈 명" 으로 작성해주세요. -->

## ✨ 구현 기능
<!-- 한 줄로 간결히 설명해주세요 -->
"나의 매물 조회" 페이지 생성 : MyArticle.jsx

## ✅ 작업 내용 상세
- [x] 페이지 마크업&스타일링
  - 인기 매물 조회와 기본 구조 동일. 지역 필터 유무 다름
  - 인기 매물 조회와 공통으로 사용되는 스타일에 대해서 컴포넌트 분리
- [x] 로그인된 유저의 매물만 노출
  - 로그인된 유저의 uid 가져와서 상품 데이터와 비교
  - 인기 매물 조회 로직 참고해서 적용 후 개선 작업
![image](https://user-images.githubusercontent.com/26590099/226693588-0ad7a4c0-33fb-4ff0-aa68-5b361dd2b065.png)

## 🙏 비고
<!-- 공유사항, 특이사항 또는 작업 회고 등 편안하게 작성해주세요 -->
코드를 이해하고 보니 조건부 렌더링이 생각보다 어렵지 않아 작업 빠르게 진행했습니다!!
개인적으로 나의 매물 조회 뿐만 아니라 내 정보를 전부 가져와 노출하는 마이페이지로 개선하는 방식은 어떨지 제안해봅니다 홀홀,,,