### PR TITLE
[#60] Home 화면에 인기 매물 8개 노출

### DIFF
--- a/potato-market/src/pages/Home.jsx
+++ b/potato-market/src/pages/Home.jsx
@@ -1,8 +1,39 @@
+import { useEffect, useState } from "react";
+
+import {onSnapshot} from "firebase/firestore"
 import styled, { createGlobalStyle } from "styled-components";
 
+import { ProductList } from "./HotArticles/HotArticles";
+import Product from "../components/product";
 import { gray1, gray2 } from "../styles/Global";
 
+import firebase from '@/firebase';
+
+const db = firebase.firestore();
+const q = db.collection("UserWrite");
+
 export default function Home(){
+  
+  const [ readyToRender, setReadyToRender] = useState(0);
+  const [checkArr, setCheckArr] = useState([]);
+  
+  useEffect(()=>{
+    onSnapshot(q, (snapshot)=>{
+      const newArr = snapshot.docs.map(doc => {
+        return {
+          id : doc.id,
+          ...doc.data()
+        }
+      })
+
+      newArr.sort((b, a) => a.check - b.check);
+      setCheckArr(newArr.slice(0, 8));
+      setReadyToRender(1);
+
+      console.log(checkArr);
+    })
+  }, [checkArr])
+
   return (
     <>
       <HomeGlobal/>
@@ -33,8 +64,20 @@ export default function Home(){
 
       <HotArticles8>
         <h2>중고거래 인기매물</h2>
-        {/* 상품목록 8개 컴포넌트 */}
-        <div>상품목록 8개 공간</div>
+        <div>
+          <ProductList>
+          {
+            readyToRender ? checkArr.map(
+              ({ content, title, price, side, imgsrc, id, check, heart }, index)=>
+              (
+                <Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />
+                )
+                ) 
+                : 
+                <p>Render Failed</p>
+              }
+          </ProductList>
+        </div>
         <UnderlineButton>
           인기매물 더보기
         </UnderlineButton>
@@ -59,6 +102,7 @@ export default function Home(){
   ) 
 }
 
+// Styled Components
 
 const HomeGlobal = createGlobalStyle`
   body {
@@ -71,7 +115,7 @@ const HomeGlobal = createGlobalStyle`
     font-weight: 700;
     font-size: 3rem;
   }
-`
+`;
 
 const MainTop = styled.section`
   background-color: #FBF7F2;
@@ -91,6 +135,7 @@ const MainTop = styled.section`
       top: 40%;
       left: 15rem;
       line-height: 1.3; 
+      width: 50rem;
     }
     
     & p {
@@ -191,14 +236,18 @@ const HotArticles8 = styled.section`
   div {
     width: 1024px;
     height: 752px;
-    background-color: aqua;
+    
     margin-left: auto;
     margin-right: auto;
-    margin-top: 85px;
+    margin-top: 3rem;
   }
-  `;
 
-  const UnderlineButton = styled.button`
+  & Product{
+
+  }
+`;
+
+const UnderlineButton = styled.button`
     margin-left: auto;
     margin-right: auto;
     background-color: transparent;

--- a/potato-market/src/pages/Home.jsx
+++ b/potato-market/src/pages/Home.jsx
@@ -30,7 +30,6 @@ export default function Home(){
       setCheckArr(newArr.slice(0, 8));
       setReadyToRender(1);
 
-      console.log(checkArr);
     })
   }, [checkArr])
 
@@ -64,20 +63,13 @@ export default function Home(){
 
       <HotArticles8>
         <h2>중고거래 인기매물</h2>
-        <div>
-          <ProductList>
-          {
-            readyToRender ? checkArr.map(
-              ({ content, title, price, side, imgsrc, id, check, heart }, index)=>
-              (
-                <Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />
-                )
-                ) 
-                : 
-                <p>Render Failed</p>
-              }
-          </ProductList>
-        </div>
+        <ProductList className="Hot8">
+          { readyToRender ? checkArr.map(
+              ({ content, title, price, side, imgsrc, id, check, heart }, index) =>
+              (<Product key={index} check={check} content={content} heart={heart} id={id} imgsrc={imgsrc} price={price} side={side} title={title} />)) 
+            : <p>Render Failed</p> 
+          }
+        </ProductList>
         <UnderlineButton>
           인기매물 더보기
         </UnderlineButton>
@@ -114,6 +106,7 @@ const HomeGlobal = createGlobalStyle`
   h2 {
     font-weight: 700;
     font-size: 3rem;
+    margin: 0 auto;
   }
 `;
 
@@ -226,24 +219,27 @@ const MainReversed = styled.section`
 const HotArticles8 = styled.section`
   background-color: ${gray2};
   padding-top: 125px;
-  padding-bottom: 11.5rem;
+  padding-bottom: 5rem;
+  margin: 0 auto;
   
   h2 {
     font-size: 40px;
     text-align: center;
+    /* display: block; */
+    width: 300px;
   }
-
-  div {
-    width: 1024px;
-    height: 752px;
+  
+  .Hot8 {
+    margin-left: 0;
+    padding-left: 20rem;
+    padding-right: 30rem;
+    margin-bottom: 5rem;
     
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 3rem;
-  }
-
-  & Product{
-
+    h2 {
+      font-size: 16px;
+      font-weight: 400;
+      text-align: left;
+    }
   }
 `;
 

--- a/potato-market/src/pages/HotArticles/HotArticles.jsx
+++ b/potato-market/src/pages/HotArticles/HotArticles.jsx
@@ -61,7 +61,7 @@ function HotArticles(){
   )
 }
 
-const ProductList = styled.section`
+export const ProductList = styled.section`
   margin: 35px auto;
   display: grid;
   gap: 55px;


### PR DESCRIPTION
<!-- PR의 제목을 "[#이슈 번호] 이슈 명" 으로 작성해주세요. -->

## ✨ 구현 기능
홈화면에 조회수 순으로 인기매물 8개 보여주기
<img width="939" alt="Screenshot 2023-03-22 at 3 15 40 AM" src="https://user-images.githubusercontent.com/68728192/226703942-92a760ba-ad80-4a50-ab5e-144a75c30c21.png">

## ✅ 작업 내용 상세
- [x] db에 등록된 아티클 중 조회수 순으로 sort하여 상위 8개를 가져옴
- [x] 홈화면에 맞는 스타일링 수정

## 🙏 비고
<!-- 공유사항, 특이사항 또는 작업 회고 등 편안하게 작성해주세요 -->