### PR TITLE
[bug-fix] 처음 켰을 때 스크롤 높이 확인 못하는 거 구현

### DIFF
--- a/potato-market/src/components/comment.jsx
+++ b/potato-market/src/components/comment.jsx
@@ -39,10 +39,12 @@ function Comment(){
   }, [onSnapshot]);
 
   useMemo(()=>{
-    setTimeout(() => {
-      scrollRef.current.scrollTop=scrollRef.current.scrollHeight
-    }, 150);
-  },[lender])
+    if(chat){
+      setTimeout(() => {
+        scrollRef.current.scrollTop=scrollRef.current.scrollHeight
+      }, 150);
+    }
+  },[lender,chat])
 
   return(
 


### PR DESCRIPTION
<!-- PR의 제목을 "[#이슈 번호] 이슈 명" 으로 작성해주세요. -->

## ✨ 구현 기능
제곧내

## ✅ 작업 내용 상세
- 버그 수정
  이유 : 처음 홈페이지 렌더링 될 때는 기본 chat값이 false기 때문에,
채팅 돔이 구현이 안됐는데도 불구하고 채팅창 ul의 높이를 찾으려니까 
높이를 찾을 수 없어서 오류가 발생 + 처음 킬 때가 아닌 렌더 기준으로 useMemo를 사용해서
처음 킬 때 높이를 안잡아줌
  고친 것 : useMemo 두번째 배열 인자에 chat 을 추가하여 버튼을 클릭할 때도 높이값 찾아서 내려가게 만들었고,
if(chat) 을 사용하여 chat이 화면에 보여질때만 높이값을 변동하게 만듦

## 🙏 비고
반박시 님들말이 맞음