### PR TITLE
[bugfix] 콘솔 경고 제거, 게시글작성&핫아티클과 푸터 사이 간격 일정하게 조절

### DIFF
--- a/potato-market/src/components/WriteForm.jsx
+++ b/potato-market/src/components/WriteForm.jsx
@@ -204,7 +204,7 @@ const ProductPriceBox = styled.div`
 const WriteButtonBox = styled.div`
   width: 218px;
   height: 40px;
-  margin: 40px auto 80px auto;
+  margin: 40px auto 0px auto;
   display: flex;
   justify-content: space-between;
   gap: 20px;

--- a/potato-market/src/components/WriteForm.jsx
+++ b/potato-market/src/components/WriteForm.jsx
@@ -27,7 +27,7 @@ function WriteForm(){
   const [formState, setFormState] = useState({
     title: '',
     side: '물품 종류',
-    price : ' - ',
+    price : '0',
     content: '',
     nickname: '',
     profileImage: '',
@@ -101,7 +101,7 @@ function WriteForm(){
 
         <ProductPriceBox>
           <WriteInput name="price" placeholder="상품 가격을 입력해주세요" required={true} type="number" value={formState.price} onChange={handleChange} />
-          <span className="productPrice">판매 가격 : {formState.price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}원</span>
+          <span className="productPrice">판매 가격 : {formState.price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원</span>
         </ProductPriceBox>
 
         <WriteInput content name="content" placeholder="내용을 입력해주세요" required={true} type="text" value={formState.content} onChange={handleChange} />      

--- a/potato-market/src/components/comment.jsx
+++ b/potato-market/src/components/comment.jsx
@@ -31,12 +31,11 @@ function Comment() {
   }
 
   useEffect(() => {
-    const fetchUser = async () => {
+    async () => {
       onSnapshot(commentRef, () => {
         setLender(0);
       });
     };
-    return fetchUser()
   }, [onSnapshot]);
 
   useMemo(() => {

--- a/potato-market/src/components/product.jsx
+++ b/potato-market/src/components/product.jsx
@@ -4,14 +4,13 @@ import styled from "styled-components";
 
 import moneyUnit from "@/utils/moneyUnit";
 
-const Div = styled.a`
-& .product{
-  display:inline-block;
-  width:201px;
-  text-decoration:none;
-  color:black;
-  cursor:pointer;
-}
+const Div = styled.div`
+  & .product{
+    display: inline-block;
+    width:201px;
+    text-decoration:none;
+    color: black;
+  }
 `
 const Section = styled.div`
   margin-bottom: 7px;
@@ -67,13 +66,13 @@ const H3 = styled.h3`
 `
 
 const PriceSpan = styled.span`
-font-weight: 700;
-margin-top:5px;
+  font-weight: 700;
+  margin-top:5px;
 `
 
 const AddressSpan = styled.span`
-font-size: 13px;
-margin-top: 5px;
+  font-size: 13px;
+  margin-top: 5px;
 `
 
 function Product({title,price,heart,chat,imgsrc,id,check,location}){

--- a/potato-market/src/pages/productdetail.jsx
+++ b/potato-market/src/pages/productdetail.jsx
@@ -435,7 +435,8 @@ const Section = styled.section`
   }
 
   & .best-product{
-    display:inline-block;
+    display: flex;
+    flex-wrap: wrap;
     margin-top: 10px;
   }
   & .best-product .product{

--- a/potato-market/src/styles/ContainerGlobalStyle.js
+++ b/potato-market/src/styles/ContainerGlobalStyle.js
@@ -3,7 +3,7 @@ import { createGlobalStyle } from 'styled-components';
 export const ContainerGlobalStyle = createGlobalStyle`
   .wrapper{
     width: 980px;
-    margin: 60px auto;
+    margin: 70px auto 120px auto;
     @media (max-width: 767px){
       width: 480px
     }


### PR DESCRIPTION
## ✨ 구현 기능
콘솔 경고 제거, 게시글작성&핫아티클과 푸터 사이 간격 일정하게 조절

## ✅ 작업 내용 상세
- [x] useEffect 오류 제거(return 문 제거)
- [x] 중첩 a 사용 제거(Product 컴포넌트 내부에 Link 를 a태그로 감싸고 있어서 생긴 이슈) -> div 로 변경 후 레이아웃 재조정 
- [x] 가격 기본값을 '-' -> 0 으로 변경
- [x] 푸터와의 간격이 일정하지 않던 레이아웃 수정
- [x] 헤더와 본문 사이의 간격이 너무 멀어서 간격 축소시킴

## 🙏 비고
아직 해결해야할 오류가 하나 남아있습니다.
![image](https://user-images.githubusercontent.com/92783354/227829720-cee8498c-d168-4732-9a90-fb4e81a3f7d1.png)
-> FilteredProducts 안에 useState 사용 오류같습니다.
