### PR TITLE
[#135] 반응형 적용에 따른 헤더, 푸터 스타일 수정

### DIFF
--- a/potato-market/src/components/Footer.jsx
+++ b/potato-market/src/components/Footer.jsx
@@ -90,18 +90,20 @@ const FooterGlobal = styled.footer`
 const Footertop = styled.section` 
   display: flex;
   flex-direction: row;
-  width : 100vw;
+  max-width: 1200px;
   height : auto;
   align-items: flex-start;
   position: relative;
-  margin: 0 auto;
   padding-top: 3rem;
-  /* justify-content: space-between; */
-
+  justify-content: space-between;
+  margin: 0 auto;
+  
+  
   @media (min-width: 375px) and (max-width: 1200px){
     margin-left: 2rem;
     height: 20rem;
     padding-top: 1rem;
+
      ul {
       margin: 0.5rem;
     }
@@ -112,7 +114,7 @@ const Footertop = styled.section`
     font-size: 0.875rem;
     margin: 0 2rem;
     position: relative;
-    right: 2rem;
+    /* right: 2rem; */
 
     li {
       margin-bottom: 2rem;
@@ -130,9 +132,9 @@ const Footertop = styled.section`
     position: absolute;
     right: 10%;
     
-    @media (min-width: 375px) and (max-width: 1200px){
+    @media (min-width: 375px) and (max-width: 768px){
       position: absolute;
-      bottom : 0;
+      bottom : 1rem;
       left: 0;
     }
 
@@ -169,24 +171,33 @@ const FooterMiddle = styled.div`
   border-top: 1px solid ${gray1};
   display: flex;
   flex-direction: row;
-  width : 100vw;
+  max-width : 1200px;
   height : auto;
   align-items: flex-start;
   position: relative;
-  margin: 1rem auto;
+  margin: 0 auto;
   justify-content: space-between;
   padding-top: 1rem;
 
-  @media (min-width: 375px) and (max-width: 1200px){
-    margin-left: 2rem;
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: center;
+    margin: auto;
+
+    .information {
+      text-align: center;
+      margin-bottom: 1rem;
+    }
+    .snsgroup {
+      margin-left: 0;
+      width: auto;
+    }
   }
 
   .information {
     color: #868B94;
     font-size: 0.813rem;
     line-height: 1.25rem;
-    /* position: absolute; */
-    /* left: 0%; */
   }
 
   .snsgroup {
@@ -205,19 +216,21 @@ const FooterMiddle = styled.div`
 `;
 
 const FooterBottom = styled.div`
-  width : 100vw;
+  max-width : 1200px;
   margin: 3rem auto;
-  /* align-items:; */
 
-  @media (min-width: 375px) and (max-width: 1200px){
-    margin-left: 2rem;
-
-    .inquirygroup {
-    margin-left: 0.25rem;
+  @media (max-width: 600px) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    .inquirygroup, .terms {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      margin-bottom: 1rem;
     }
-
     a {
-      margin : 0.5rem;
+      margin: 0.5rem;
     }
   }
 
@@ -245,7 +258,7 @@ const FooterBottom = styled.div`
   a:hover {
     text-decoration : underline;
   }
-
+  
 `;
 
 export default Footer;

--- a/potato-market/src/components/Footer.jsx
+++ b/potato-market/src/components/Footer.jsx
@@ -11,25 +11,27 @@ const Footer = () => {
   return (
     <FooterGlobal>
       <Footertop>
-        <ul>
-          <li>중고거래</li>
-          <li>매물 등록하기</li>
-          <li>나의 매물보기</li>
-          <li>동네가게</li>
-          <li>채팅하기</li>
-        </ul>
-        <ul>  
-          <li>당근 비즈니스</li>
-          <li>부동산 직거래</li>
-          <li>중고차 직거래</li>
-          <li>당근알바</li>
-          <li></li>
-        </ul>      
-        <ul>
-          <li>자주 묻는 질문</li>
-          <li>회사 소개</li>
-          <li>인재 채용</li>
-        </ul>
+        <div className="footer-list">
+          <ul>
+            <li>중고거래</li>
+            <li>매물 등록하기</li>
+            <li>나의 매물보기</li>
+            <li>동네가게</li>
+            <li>채팅하기</li>
+          </ul>
+          <ul>  
+            <li>당근 비즈니스</li>
+            <li>부동산 직거래</li>
+            <li>중고차 직거래</li>
+            <li>당근알바</li>
+            <li></li>
+          </ul>      
+          <ul>
+            <li>자주 묻는 질문</li>
+            <li>회사 소개</li>
+            <li>인재 채용</li>
+          </ul>
+        </div>
 
         <div className="download-app">
           <p>감자마켓 앱 다운로드</p>
@@ -91,6 +93,7 @@ const Footertop = styled.section`
   display: flex;
   flex-direction: row;
   max-width: 1200px;
+  width: 100vw;
   height : auto;
   align-items: flex-start;
   position: relative;
@@ -98,15 +101,14 @@ const Footertop = styled.section`
   justify-content: space-between;
   margin: 0 auto;
   
-  
-  @media (min-width: 375px) and (max-width: 1200px){
-    margin-left: 2rem;
-    height: 20rem;
-    padding-top: 1rem;
-
-     ul {
-      margin: 0.5rem;
+  @media (max-width: 564px) {
+      flex-direction: column;
     }
+  
+  .footer-list {
+    display: flex;
+    align-items: flex-start;
+    
   }
 
   ul {
@@ -131,39 +133,38 @@ const Footertop = styled.section`
     display: block;
     position: absolute;
     right: 10%;
-    
-    @media (min-width: 375px) and (max-width: 768px){
-      position: absolute;
-      bottom : 1rem;
-      left: 0;
+    /* position: static; */
+    margin: 1rem auto;
+
+    @media (max-width: 1200px) {
+      position: static;
     }
 
     p {
       font-weight: 700;
       font-size: 0.875rem;
     }
-        
+
     .logobox {
       margin-top: 1rem;
-      
+
       button {
         width: 140px;
         height: 40px;
         background-color: ${gray4};
         color: #212325;
-        background-position: 24px 12px; 
+        background-position: 24px 12px;
         background-image: url(${githubLogo});
         background-repeat: no-repeat;
         background-size: 16px;
         cursor: pointer;
         vertical-align: middle;
-        padding-left: 16px;  
+        padding-left: 16px;
         border: 0;
         border-radius: 6px;
         font-weight: 700;
       }
     }
-
   }
 `;
 
@@ -172,6 +173,7 @@ const FooterMiddle = styled.div`
   display: flex;
   flex-direction: row;
   max-width : 1200px;
+  width: 100vw;
   height : auto;
   align-items: flex-start;
   position: relative;
@@ -218,7 +220,7 @@ const FooterMiddle = styled.div`
 const FooterBottom = styled.div`
   max-width : 1200px;
   margin: 3rem auto;
-
+  width: 100vw;
   @media (max-width: 600px) {
     display: flex;
     flex-direction: column;

--- a/potato-market/src/components/Header.jsx
+++ b/potato-market/src/components/Header.jsx
@@ -83,7 +83,8 @@ const HeaderWrap = styled.header`
   justify-content: center;
   flex-wrap: wrap;
   position: relative;
-
+  background-color: #fff;
+  
   .a11yHidden {
     display: inline-block;
     overflow: hidden;
@@ -94,12 +95,12 @@ const HeaderWrap = styled.header`
     height: 1px;
     margin: -1px;
   }
-
+  
   Link {
     width: 101px;
     height: 26px;
   }
-
+  
   img {
     width: 101px;
     height: 26px;
@@ -107,7 +108,7 @@ const HeaderWrap = styled.header`
     margin-top: 16px;
     margin-right: 35px;
   }
-
+  
   .primary {
     color: ${primaryColor};
   }
@@ -115,13 +116,21 @@ const HeaderWrap = styled.header`
   .primary:hover {
     color: ${primaryColor};
   }
-
+  
   @media (max-width: 768px){
-
+    background-color: #fff;
+    position: fixed;
     justify-content: space-between;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 999;
+
     img {
       margin-left: 2rem;
+      background-color: inherit;
     }
+
   }
 
 `;
@@ -253,6 +262,7 @@ const Icon = styled.button`
 
   @media (min-width: 768px) {
     display: none;
+    background: #fff;
   }
 `;
 

--- a/potato-market/src/components/Toggle.jsx
+++ b/potato-market/src/components/Toggle.jsx
@@ -70,6 +70,9 @@ const Div = styled.div`
 			}
 	}
 	
+	@media (max-width: 768px){
+		display: none;
+	}
 `;
 
 export default Toggle;


### PR DESCRIPTION
<!-- PR의 제목을 "[#이슈 번호] 이슈 명" 으로 작성해주세요. -->

## ✨ 구현 기능
반응형 적용에 따른 스타일 수정이 있었습니다. 

## ✅ 작업 내용 상세
- [x] 푸터 반응형 틀어짐 교정
<img width="1258" alt="Screenshot 2023-03-28 at 11 28 35 AM" src="https://user-images.githubusercontent.com/68728192/228111598-53336d00-aa1a-4503-9f89-b2e491c541a7.png">

- [x] 헤더 토글박스 모바일 메뉴 적용 시 사라지게 함

- [x] 헤더 모바일 메뉴 상단 고정 
<img width="674" alt="Screenshot 2023-03-28 at 11 27 24 AM" src="https://user-images.githubusercontent.com/68728192/228111452-2210c8b0-4355-46b5-a0b6-1db575ed31dd.png">

## 🙏 비고
<!-- 공유사항, 특이사항 또는 작업 회고 등 편안하게 작성해주세요 -->

반응형 공부 열심히 해야겠습니다...ㅠ