### PR TITLE
[Bugfix#000] Addphoto x 버튼 경로 수정 / 홈화면에서 채팅창 타이틀 가운데정렬 되는 현상(왼쪽 정렬로 변경) / 채팅, 댓글 빈문자열일 때 전송되지 않도록 변경

### DIFF
--- a/potato-market/src/components/AddPhoto.jsx
+++ b/potato-market/src/components/AddPhoto.jsx
@@ -3,10 +3,10 @@ import { useEffect } from "react";
 import imageCompression from "browser-image-compression";
 import styled from 'styled-components';
 
+import { WriteInput } from "./WriteForm";
+
 import addIcon from "@/assets/icon-add-photo.svg"
 import closeButton from "@/assets/icon-close-button.svg"
-
-import { WriteInput } from "./WriteForm";
 
 import { gray4, primaryColor } from "@/styles/global";
 

--- a/potato-market/src/components/AddPhoto.jsx
+++ b/potato-market/src/components/AddPhoto.jsx
@@ -4,6 +4,7 @@ import imageCompression from "browser-image-compression";
 import styled from 'styled-components';
 
 import addIcon from "@/assets/icon-add-photo.svg"
+import closeButton from "@/assets/icon-close-button.svg"
 
 import { WriteInput } from "./WriteForm";
 
@@ -57,7 +58,7 @@ function AddPhoto({myinputRef, name, required, postImg, setPostImg, previewImg, 
         previewImg.map((url, index) => {
           return <ProductImage key={url}>
             <button type="button" onClick={()=>removeImage(index)}>
-              <img alt="업로드 이미지 제거" src="@/assets/icon-close-button.svg" />
+              <img alt="업로드 이미지 제거" src={closeButton} />
             </button>
             <img alt={url} src={url} />
           </ProductImage>

--- a/potato-market/src/components/Recommend.jsx
+++ b/potato-market/src/components/Recommend.jsx
@@ -17,7 +17,9 @@ function Recommend({ recommend }) {
   useEffect(()=>{    
     inputValue.current.value = "";
   })
-  const sendHandler = () =>{  
+  const sendHandler = () =>{
+    if(inputValue.current.value==="") return;
+    
     const userRef = doc(db,"UserWrite",uid.id);
     const userSnap = getDoc(userRef);   
     userSnap.then((item)=>{

--- a/potato-market/src/components/comment.jsx
+++ b/potato-market/src/components/comment.jsx
@@ -48,6 +48,7 @@ function Comment() {
   }, [lender, chat])
 
   const sendMessage = () => {
+    if(inputValue.current.value==="") return;
     const userRef = doc(db, "comment", "kviERzom8LpJItP3g23N");
     const userSnap = getDoc(userRef);
     userSnap.then((item) => {

--- a/potato-market/src/components/comment.jsx
+++ b/potato-market/src/components/comment.jsx
@@ -154,12 +154,14 @@ const Div = styled.div`
     padding: 0 20px;
     box-sizing: border-box;
   }
-  & .chat-h2{
+  & .header-div h2.chat-h2{
     width: 100%;
     height: 30px;
     line-height: 30px;
     margin:0;
     font-size:15px;
+    font-weight: 700;
+    text-align: left;
   }
 
   & .chat-false-button, & .reset-button{

--- a/potato-market/src/pages/productdetail.jsx
+++ b/potato-market/src/pages/productdetail.jsx
@@ -204,7 +204,7 @@ function Productdetail({ recommend, state, title, side, nickname, profileImage, 
           <form>
             <h3>정말로 삭제하시겠습니까?</h3>
             <div className="button-wrapper">
-              <CustomButton red onClick={(e) => {
+              <CustomButton filled onClick={(e) => {
                 e.preventDefault();
                 deleteDoc(doc(db, "UserWrite", paramsId.id)).then(() => { navigate("/HotArticles"); })
               }}>삭제</CustomButton>
@@ -224,8 +224,7 @@ function Productdetail({ recommend, state, title, side, nickname, profileImage, 
               <WriteInput className="price-input" name="modifiedPrice" type="number" value={modifiedContent.modifiedPrice} onChange={onChangeHandler} />
             </div>
             <WriteInput content className="content-input" name="modifiedContent" type="text" value={modifiedContent.modifiedContent} onChange={onChangeHandler} />
-            <div className="button-wrapper">
-              <CustomButton onClick={() => { setClickModified(0) }}>취소</CustomButton>
+            <div className="button-wrapper">              
               <CustomButton className="modifie-button" onClick={() => {
                 const newObj = {
                   content: modifiedContent.modifiedContent,
@@ -238,6 +237,7 @@ function Productdetail({ recommend, state, title, side, nickname, profileImage, 
                   })
                 })
               }}>수정</CustomButton>
+              <CustomButton onClick={() => { setClickModified(0) }}>취소</CustomButton>
             </div>
           </form>
         </ModifiedDiv> : null
@@ -319,6 +319,9 @@ const ModifiedDiv = styled.div`
   }
   & .price-input{
     width: 150px;
+  }
+  & .price-input::-webkit-inner-spin-button {
+    appearance: none;
   }
   & .content-input{
     width: 673.5px;


### PR DESCRIPTION
## ✨ 구현 기능
Addphoto 경로 수정
홈화면에서 채팅창 타이틀 가운데정렬 되는 현상(왼쪽 정렬로 변경)
채팅, 댓글 빈문자열일 때 전송되지 않도록 변경

## ✅ 작업 내용 상세
- [x] Addphoto x 버튼 경로 수정
- [x] 홈화면에서 채팅창 타이틀 가운데정렬 되는 현상(왼쪽 정렬로 변경)
- [x] 삭제 눌렀을때 나오는 모달창의 삭제 버튼 스타일 다시 적용
- [x] 채팅, 댓글 빈문자열일 때 전송되지 않도록 변경

## 🙏 비고
